### PR TITLE
Origin/solve rootfinder with negative pressure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,12 @@ testtillpressure: testtillpressure.o $(objects)
 	cc -o testtillpressure testtillpressure.o $(objects) $(LIBS)
 
 #
+# Test the function tillPressureNP.
+#
+testtillpressure_np: testtillpressure_np.o $(objects)
+	cc -o testtillpressure_np testtillpressure_np.o $(objects) $(LIBS)
+
+#
 # Test the function tillPressureSound.
 #
 testtillsound: testtillsound.o $(objects)

--- a/plottillpressure.py
+++ b/plottillpressure.py
@@ -87,8 +87,8 @@ print "rho_min=", min(rho), "rho_max=", max(rho)
 print "u_min  =", min(u), "u_max  =", max(u)
 
 # Convert to cgs
-rho /= dGmPerCcUnit
-u   /= dErgPerGmUnit
+rho *= dGmPerCcUnit
+u   *= dErgPerGmUnit
 
 #data /= (dErgPerGmUnit*dGmPerCcUnit)
 #data /= (dGmPerCcUnit*dErgPerGmUnit)

--- a/testrhoptemp.c
+++ b/testrhoptemp.c
@@ -26,10 +26,10 @@ int main(int argc, char **argv) {
 	int nV = 1000;
     int iMat = GRANITE;
     // Grid
-    double P_min = 0.0;
-    double P_max = 1e3;
+    double P_min = 1e-8;
+    double P_max = 1e2;
     double T_min = 0.0;
-    double T_max = 1e3;
+    double T_max = 1e5;
     int nP = 1000;
     int nT = 1000;
 	double rho, u;
@@ -51,7 +51,7 @@ int main(int argc, char **argv) {
 	/*
 	 * Print rho on a P x T grid.
 	 */	
-	fp = fopen("testtillrhoptemp.txt", "w");
+	fp = fopen("testrhoptemp.txt", "w");
 	assert(fp != NULL);
 
 	fprintf(stderr, "Printing grid...\n");
@@ -64,6 +64,30 @@ int main(int argc, char **argv) {
 		{
 		    P = P_min + j*dP;
 			fprintf(fp," %15.7E", tillRhoPTemp(tillmat, P, T));
+		}
+		fprintf(fp,"\n");
+	}
+	fclose(fp);
+
+    /*
+     * Compare the difference in pressure when using rho(P, T).
+     */
+	fp = fopen("testrhoptemp_diff.txt", "w");
+	assert(fp != NULL);
+
+	fprintf(stderr, "Printing grid...\n");
+
+	for (i=0; i<nT; i+=1)
+	{
+		T = T_min + i*dT;
+
+		for (j=0; j<nP; j+=1)
+		{
+		    P = P_min + j*dP;
+
+			rho = tillRhoPTemp(tillmat, P, T);
+
+			fprintf(fp," %15.7E", tillPressureRhoT(tillmat, rho, T)-P);
 		}
 		fprintf(fp,"\n");
 	}

--- a/testrhoptemp.c
+++ b/testrhoptemp.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
     dT = (T_max-T_min)/(nT-1);
     
     // Zoom in
-	rho_max = 25.0;
+	rho_max = 10.0;
     rho_min = 1e-4;
     drho = (rho_max-rho_min)/(nRho-1);
 
@@ -115,9 +115,19 @@ int main(int argc, char **argv) {
 		    rho = rho_min + j*drho;
             P = eosPressureRhoT(tillmat, rho, T);
 
-            printf("rho = %g T= %g P= %g\n", rho, T, P);
+            // Avoid weird densities if the root finding fails.
+            if (P <= 0.0) {
+                printf("rho = %g T= %g P= %g\n", rho, T, P);
+                fprintf(fp," %3i", -1);
+            } else {
+                if (fabs(tillRhoPTemp(tillmat, P, T)-rho) < 1e-3) {
+                    fprintf(fp," %3i", 0);
+                } else {
+                    fprintf(fp," %3i", 1);
+                }
 
-			fprintf(fp," %15.7E", tillRhoPTemp(tillmat, P, T)-rho);
+//                fprintf(fp," %15.7E", tillRhoPTemp(tillmat, P, T)-rho);
+            }
 		}
 		fprintf(fp,"\n");
 	}

--- a/testrhoptemp.c
+++ b/testrhoptemp.c
@@ -1,0 +1,74 @@
+/*
+ * This is a simple program to test the Tillotson EOS library.
+ *
+ * Author: Christian Reinhardt
+ * Date:   06.04.2019
+ *
+ * Test if eosRhoPTemp can bracket the root for all pressures and temperatures on a grid.
+ */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "tillotson.h"
+
+#define INDEX(i, j) (((i)*granite->nTableV) + (j))
+
+int main(int argc, char **argv) {
+    // Tillotson EOS
+    TILLMATERIAL *tillmat;
+	double dKpcUnit = 2.06701e-13;
+	double dMsolUnit = 4.80438e-08;
+	double rhomax = 100.0;
+    double rhomin = 1e-4;
+	double vmax = 1200.0;
+	int nRho = 1000;
+	int nV = 1000;
+    int iMat = GRANITE;
+    // Grid
+    double P_min = 0.0;
+    double P_max = 1e3;
+    double T_min = 0.0;
+    double T_max = 1e3;
+    int nP = 1000;
+    int nT = 1000;
+	double rho, u;
+    double P, T;
+    double dP, dT;
+	double rhoPT;
+	FILE *fp = NULL;
+	int i, j;
+
+    // Initialize the Tillotson EOS
+	fprintf(stderr, "Initializing material...\n");
+	tillmat = tillInitMaterial(iMat, dKpcUnit, dMsolUnit);
+	tillInitLookup(tillmat, nRho, nV, rhomin, rhomax, vmax);
+	fprintf(stderr, "Done.\n");
+	
+    dP = (P_max-P_nin)/(nP-1);
+    dT = (T_max-T_min)/(nT-1);
+
+	/*
+	 * Print rho on a P x T grid.
+	 */	
+	fp = fopen("testtillrhoptemp.txt", "w");
+	assert(fp != NULL);
+
+	fprintf(stderr, "Printing grid...\n");
+
+	for (i=0; i<nT; i+=1)
+	{
+		T = T_min + i*dT;
+
+		for (j=0; j<nP; j+=1)
+		{
+		    P = P_min + j*dP;
+			fprintf(fp," %15.7E", tillRhoPTemp(tillmat, P, T));
+		}
+		fprintf(fp,"\n");
+	}
+	fclose(fp);
+
+	fprintf(stderr,"Done.\n");
+	tillFinalizeMaterial(granite);
+}

--- a/testrhoptemp.c
+++ b/testrhoptemp.c
@@ -1,8 +1,9 @@
 /*
  * This is a simple program to test the Tillotson EOS library.
  *
- * Author: Christian Reinhardt
- * Date:   06.04.2019
+ * Author:   Christian Reinhardt
+ * Date:     06.04.2019
+ * Modified: 07.04.2019
  *
  * Test if eosRhoPTemp can bracket the root for all pressures and temperatures on a grid.
  */
@@ -19,9 +20,9 @@ int main(int argc, char **argv) {
     TILLMATERIAL *tillmat;
 	double dKpcUnit = 2.06701e-13;
 	double dMsolUnit = 4.80438e-08;
-	double rhomax = 100.0;
-    double rhomin = 1e-4;
-	double vmax = 1200.0;
+	double rho_max = 100.0;
+    double rho_min = 1e-4;
+	double v_max = 1200.0;
 	int nRho = 1000;
 	int nV = 1000;
     int iMat = GRANITE;
@@ -34,19 +35,23 @@ int main(int argc, char **argv) {
     int nT = 1000;
 	double rho, u;
     double P, T;
-    double dP, dT;
-	double rhoPT;
+    double dP, dT, drho;
 	FILE *fp = NULL;
 	int i, j;
 
     // Initialize the Tillotson EOS
 	fprintf(stderr, "Initializing material...\n");
 	tillmat = tillInitMaterial(iMat, dKpcUnit, dMsolUnit);
-	tillInitLookup(tillmat, nRho, nV, rhomin, rhomax, vmax);
+	tillInitLookup(tillmat, nRho, nV, rho_min, rho_max, v_max);
 	fprintf(stderr, "Done.\n");
 	
     dP = (P_max-P_min)/(nP-1);
     dT = (T_max-T_min)/(nT-1);
+    
+    // Zoom in
+	rho_max = 25.0;
+    rho_min = 1e-4;
+    drho = (rho_max-rho_min)/(nRho-1);
 
 	/*
 	 * Print rho on a P x T grid.
@@ -87,7 +92,32 @@ int main(int argc, char **argv) {
 
 			rho = tillRhoPTemp(tillmat, P, T);
 
-			fprintf(fp," %15.7E", tillPressureRhoT(tillmat, rho, T)-P);
+			fprintf(fp," %15.7E", eosPressureRhoT(tillmat, rho, T)-P);
+		}
+		fprintf(fp,"\n");
+	}
+	fclose(fp);
+
+    /*
+     * Compare the difference in rho due to root finding.
+     */
+	fp = fopen("testrhoptemp_rhot.txt", "w");
+	assert(fp != NULL);
+
+	fprintf(stderr, "Printing grid...\n");
+
+	for (i=0; i<nT; i+=1)
+	{
+		T = T_min + i*dT;
+
+		for (j=0; j<nRho; j+=1)
+		{
+		    rho = rho_min + j*drho;
+            P = eosPressureRhoT(tillmat, rho, T);
+
+            printf("rho = %g T= %g P= %g\n", rho, T, P);
+
+			fprintf(fp," %15.7E", tillRhoPTemp(tillmat, P, T)-rho);
 		}
 		fprintf(fp,"\n");
 	}

--- a/testrhoptemp.c
+++ b/testrhoptemp.c
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
 	tillInitLookup(tillmat, nRho, nV, rhomin, rhomax, vmax);
 	fprintf(stderr, "Done.\n");
 	
-    dP = (P_max-P_nin)/(nP-1);
+    dP = (P_max-P_min)/(nP-1);
     dT = (T_max-T_min)/(nT-1);
 
 	/*
@@ -70,5 +70,7 @@ int main(int argc, char **argv) {
 	fclose(fp);
 
 	fprintf(stderr,"Done.\n");
-	tillFinalizeMaterial(granite);
+	tillFinalizeMaterial(tillmat);
+
+    return 0;
 }

--- a/testrhoptemp.c
+++ b/testrhoptemp.c
@@ -49,7 +49,7 @@ int main(int argc, char **argv) {
     dT = (T_max-T_min)/(nT-1);
     
     // Zoom in
-	rho_max = 10.0;
+	rho_max = 8.0;
     rho_min = 1e-4;
     drho = (rho_max-rho_min)/(nRho-1);
 

--- a/testrhoptemp.py
+++ b/testrhoptemp.py
@@ -87,11 +87,14 @@ rho_max = 8.0602
 u_min   = 0.0
 u_max   = 19.8035
 """
-P_min = 0.0
-P_max = 1e3
+P_min   = 0.0
+P_max   = 1e3
 
-T_min = 0.0
-T_max = 1e3
+T_min   = 0.0
+T_max   = 1e3
+
+rho_min = 1e-4
+rho_max = 8.0
 
 """
 # Convert to cgs
@@ -151,7 +154,7 @@ data = loadtxt('testrhoptemp_rhot.txt')
 
 print where(fabs(data) < 1e-10)
 
-imshow(data, origin='lower', extent=(P_min, P_max, T_min, T_max), aspect='auto')
+imshow(data, origin='lower', extent=(rho_min, rho_max, T_min, T_max), aspect='auto')
 
 xlabel("Density [code units]")
 ylabel("Temperature [K]")
@@ -159,4 +162,4 @@ ylabel("Temperature [K]")
 colorbar()
 
 savefig('testrhoptemp_rhot.png', dpi=300, bbox_inches='tight')
-
+show()

--- a/testrhoptemp.py
+++ b/testrhoptemp.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python2
+"""
+This script plots the results of testrhoptemp.c.
+"""
+from matplotlib import *
+rcParams['font.family'] = 'serif'
+from numpy import *
+from matplotlib.pyplot import *
+
+"""
+Setup the plot.
+"""
+# Set a font
+rcParams['font.family'] = 'serif'
+rcParams['font.size'] = 10.0
+
+# Legend
+# mpl.rcParams['legend.handlelength']  = 2.9
+rcParams['legend.handlelength']  = 0.5
+rcParams['legend.frameon']       = False
+rcParams['legend.numpoints']     = 1
+rcParams['legend.scatterpoints'] = 1
+
+# Adjust axes line width
+rcParams['axes.linewidth']   = 0.5
+
+# Adjust ticks
+rcParams['xtick.major.size'] = 4
+rcParams['xtick.minor.size'] = 2
+rcParams['ytick.major.size'] = 4
+rcParams['ytick.minor.size'] = 2
+
+# Adjust Font Size
+rcParams['xtick.labelsize']  = 'xx-small'
+rcParams['ytick.labelsize']  = 'xx-small'
+rcParams['axes.labelsize']   = 'x-small'
+
+# Set Up Figure, Single Column MNRAS
+fig = gcf()
+ax = gca()
+fig, ax = subplots(1,1)
+fig.set_size_inches(8.27*0.39,8.27*(6./8.)*0.39)
+
+# Physical constants used for unit convertion (cgs)
+KBOLTZ = 1.38e-16		# bolzman constant in cgs
+MHYDR  = 1.67e-24		# mass of hydrogen atom in grams
+MSOLG  = 1.99e33		# solar mass in grams
+GCGS   = 6.67e-8		# G in cgs
+KPCCM  = 3.085678e21		# kiloparsec in centimeters
+
+# These two values define the unit system we use
+dKpcUnit  = 2.06701e-13	        # kiloparsec in code units
+dMsolUnit = 4.80438e-08	        # solar mass in code units
+
+# Mass of Earth
+MEarth = 5.98e27		# g
+MSun   = 1.989e33	        # g
+
+"""
+Convert kboltz/mhydrogen to system units, assuming that
+G == 1.
+"""
+# code energy per unit mass --> erg per g
+dErgPerGmUnit = GCGS*dMsolUnit*MSOLG/(dKpcUnit*KPCCM)
+# code density --> g per cc
+dGmPerCcUnit = (dMsolUnit*MSOLG)/pow(dKpcUnit*KPCCM,3.0)
+# code time --> seconds
+dSecUnit = sqrt(1/(dGmPerCcUnit*GCGS))
+
+# The units are not nescessary but can be derived from the quanities above
+Lunit = dKpcUnit*KPCCM
+Munit = dMsolUnit*MSOLG
+
+# Reference density (material dependent)
+rho0 = 2.7
+us   = 3.5e10
+us2  = 1.8e11
+
+"""
+rho_min = 1e-4
+rho_max = 10.0
+u_min   = 0.0
+u_max   = 25.0
+
+rho_min = 1e-4
+rho_max = 8.0602
+u_min   = 0.0
+u_max   = 19.8035
+"""
+P_min = 0.0
+P_max = 1e3
+
+T_min = 0.0
+T_max = 1e3
+
+"""
+# Convert to cgs
+rho_min *= dGmPerCcUnit
+rho_max *= dGmPerCcUnit
+
+u_min   *= dErgPerGmUnit
+u_max   *= dErgPerGmUnit
+
+print dGmPerCcUnit
+print dErgPerGmUnit
+
+print "rho_min=", rho_min, "rho_max=", rho_max
+print "u_min  =", u_min, "u_max  =", u_max
+"""
+
+"""
+Plot rho(P, T).
+"""
+data = loadtxt('testtillpressure_np_diff.txt')
+
+print where(fabs(data) < 1e-10)
+
+imshow(data, origin='lower', extent=(rho_min, rho_max, u_min, u_max), aspect='auto')
+
+xlabel("Pressure [code units]")
+ylabel("Temperature [K]")
+
+colorbar()
+
+savefig('testrhoptemp.png', dpi=300, bbox_inches='tight')
+
+fig.clear()
+
+
+

--- a/testrhoptemp.py
+++ b/testrhoptemp.py
@@ -111,11 +111,11 @@ print "u_min  =", u_min, "u_max  =", u_max
 """
 Plot rho(P, T).
 """
-data = loadtxt('testtillpressure_np_diff.txt')
+data = loadtxt('testrhoptemp.txt')
 
 print where(fabs(data) < 1e-10)
 
-imshow(data, origin='lower', extent=(rho_min, rho_max, u_min, u_max), aspect='auto')
+imshow(data, origin='lower', extent=(P_min, P_max, T_min, T_max), aspect='auto')
 
 xlabel("Pressure [code units]")
 ylabel("Temperature [K]")
@@ -126,5 +126,37 @@ savefig('testrhoptemp.png', dpi=300, bbox_inches='tight')
 
 fig.clear()
 
+"""
+Plot P(rho, T)-P.
+"""
+data = loadtxt('testrhoptemp_diff.txt')
 
+print where(fabs(data) < 1e-10)
+
+imshow(data, origin='lower', extent=(P_min, P_max, T_min, T_max), aspect='auto')
+
+xlabel("Pressure [code units]")
+ylabel("Temperature [K]")
+
+colorbar()
+
+savefig('testrhoptemp_diff.png', dpi=300, bbox_inches='tight')
+
+fig.clear()
+
+"""
+Plot rho(P, T)-rho.
+"""
+data = loadtxt('testrhoptemp_rhot.txt')
+
+print where(fabs(data) < 1e-10)
+
+imshow(data, origin='lower', extent=(P_min, P_max, T_min, T_max), aspect='auto')
+
+xlabel("Density [code units]")
+ylabel("Temperature [K]")
+
+colorbar()
+
+savefig('testrhoptemp_rhot.png', dpi=300, bbox_inches='tight')
 

--- a/testtillpressure_np.c
+++ b/testtillpressure_np.c
@@ -105,8 +105,18 @@ void main(int argc, char **argv) {
 		{
             rho = rhomin + j*drho;
 
-			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL)-
+            double P;
+            P = fabs(tillPressureSoundNP(tillmat, rho, u, NULL)-tillPressure(tillmat, rho, u));
+
+            if (P > 0.0) {
+                fprintf(fp," %2i", 0);
+            } else {
+                fprintf(fp," %2i", 1);
+            }
+#if 0
+            fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL)-
                     tillPressure(tillmat, rho, u));
+#endif
 		}
 		fprintf(fp,"\n");
 	}
@@ -124,8 +134,8 @@ void main(int argc, char **argv) {
 		for (j=0; j<nRho; j+=1)
 		{
             rho = rhomin + j*drho;
-//            if (tillPressureSoundNP(tillmat, rho, u, NULL) <= 0.0)
-            if (tillPressureSound(tillmat, rho, u, NULL) <= 0.0)
+            if (tillPressureSoundNP(tillmat, rho, u, NULL) <= 0.0)
+//            if (tillPressureSound(tillmat, rho, u, NULL) <= 0.0)
             {
                 fprintf(fp," %2i", 0);
             } else {

--- a/testtillpressure_np.c
+++ b/testtillpressure_np.c
@@ -1,0 +1,107 @@
+/*
+ * This is a simple program to test the Tillotson EOS library.
+ *
+ * Author:   Christian Reinhardt
+ * Date:     04.03.2019
+ *
+ * Calculate the pressure of a material with tillPressureSoundNP() and check if it agrees with
+ * tillPressure().
+ */
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include "tillotson.h"
+
+#define INDEX(i, j) ((i*tillmat->nTableV) + (j))
+
+void main(int argc, char **argv) {
+	double dKpcUnit = 2.06701e-13;
+	double dMsolUnit = 4.80438e-08;
+    // Define the size of the grid
+    double rhomin = 1e-4;
+	double rhomax = 100.0;
+    double vmax = 100.0;
+	double umax = 100.0;
+	double umin = 0.0;
+	int nRho = 1000;
+	int nU = 1000;
+    double drho, dU;
+
+	double rho;
+    double u;
+
+	TILLMATERIAL *tillmat;
+	FILE *fp = NULL;
+
+	int i = 0;
+	int j = 0;
+
+    drho = (rhomax-rhomin)/(nRho-1);
+    dU = (umax-umin)/(nU-1);
+
+	fprintf(stderr, "Initializing material...\n");
+	tillmat = tillInitMaterial(GRANITE, dKpcUnit, dMsolUnit);
+	fprintf(stderr, "Done.\n");
+
+	/*
+	 * Print P on a rho x u grid.
+	 */	
+	fp = fopen("testtillpressure_np.txt", "w");
+	assert(fp != NULL);
+
+	fprintf(stderr, "Printing grid using tillPressureSoundNP()...\n");
+
+	/* Print a rho x u grid. */
+	for (i=0; i<nRho; i+=1)
+	{
+		rho = rhomin + i*drho;
+		for (j=0; j<nU; j+=1)
+		{
+			u = umin + j*dU;
+			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL));
+		}
+		fprintf(fp,"\n");
+	}
+	fclose(fp);
+
+	fp = fopen("testtillpressure.txt", "w");
+	assert(fp != NULL);
+
+	fprintf(stderr, "Printing grid using tillPressure()...\n");
+
+	/* Print a rho x u grid. */
+	for (i=0; i<nRho; i+=1)
+	{
+		rho = rhomin + i*drho;
+		for (j=0; j<nU; j+=1)
+		{
+			u = umin + j*dU;
+			fprintf(fp," %15.7E", tillPressure(tillmat, rho, u));
+		}
+		fprintf(fp,"\n");
+	}
+	fclose(fp);
+
+	fp = fopen("testtillpressure_np_diff.txt", "w");
+	assert(fp != NULL);
+
+	fprintf(stderr, "Printing grid for the ideal gas EOS...\n");
+
+	/* Print a rho x u grid. */
+	for (i=0; i<nRho; i+=1)
+	{
+		rho = rhomin + i*drho;
+
+		for (j=0; j<nU; j+=1)
+		{
+			u = umin + j*dU;
+			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL)-
+                    tillPressure(tillmat, rho, u));
+		}
+		fprintf(fp,"\n");
+	}
+
+	fclose(fp);
+	tillFinalizeMaterial(tillmat);
+}

--- a/testtillpressure_np.c
+++ b/testtillpressure_np.c
@@ -24,8 +24,8 @@ void main(int argc, char **argv) {
     double vmax = 100.0;
 	double umax = 25.0;
 	double umin = 0.0;
-	int nRho = 100;
-	int nU = 100;
+	int nRho = 500;
+	int nU = 500;
     double drho, dU;
 
 	double rho;
@@ -84,20 +84,18 @@ void main(int argc, char **argv) {
 	fclose(fp);
 
 	fp = fopen("testtillpressure_np_diff.txt", "w");
-	assert(fp != null);
-
-	fprintf(stderr, "printing grid for the ideal gas eos...\n");
+	assert(fp != NULL);
 
 	/* print a rho x u grid. */
-	for (i=0; i<nrho; i+=1)
+	for (i=0; i<nRho; i+=1)
 	{
 		rho = rhomin + i*drho;
 
-		for (j=0; j<nu; j+=1)
+		for (j=0; j<nU; j+=1)
 		{
-			u = umin + j*du;
-			fprintf(fp," %15.7e", tillpressuresoundnp(tillmat, rho, u, null)-
-                    tillpressure(tillmat, rho, u));
+			u = umin + j*dU;
+			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL)-
+                    tillPressure(tillmat, rho, u));
 		}
 		fprintf(fp,"\n");
 	}
@@ -105,18 +103,18 @@ void main(int argc, char **argv) {
 
     /* Plot where P is negative. */
 	fp = fopen("testtillpressure_np_region.txt", "w");
-	assert(fp != null);
+	assert(fp != NULL);
 
 	/* print a rho x u grid. */
-	for (i=0; i<nrho; i+=1)
+	for (i=0; i<nRho; i+=1)
 	{
 		rho = rhomin + i*drho;
 
-		for (j=0; j<nu; j+=1)
+		for (j=0; j<nU; j+=1)
 		{
-			u = umin + j*du;
+			u = umin + j*dU;
             
-            if (tillpressuresoundnp(tillmat, rho, u, null) < 0.0)
+            if (tillPressureSoundNP(tillmat, rho, u, NULL) < 0.0)
             {
                 fprintf(fp," %3i", -1);
             } else {

--- a/testtillpressure_np.c
+++ b/testtillpressure_np.c
@@ -24,8 +24,8 @@ void main(int argc, char **argv) {
     double vmax = 100.0;
 	double umax = 25.0;
 	double umin = 0.0;
-	int nRho = 500;
-	int nU = 500;
+	int nRho = 1000;
+	int nU = 1000;
     double drho, dU;
 
 	double rho;
@@ -37,12 +37,20 @@ void main(int argc, char **argv) {
 	int i = 0;
 	int j = 0;
 
-    drho = (rhomax-rhomin)/(nRho-1);
-    dU = (umax-umin)/(nU-1);
-
 	fprintf(stderr, "Initializing material...\n");
 	tillmat = tillInitMaterial(GRANITE, dKpcUnit, dMsolUnit);
 	fprintf(stderr, "Done.\n");
+
+    /*
+     * Zoom in to the expanded states.
+     */
+    rhomax = 1.1*tillmat->rho0;
+    umax = 1.1*tillmat->us2;
+
+    fprintf(stderr, "rhomin= %g rhomax= %g umin= %g umax= %g\n", rhomin, rhomax, umin, umax);
+
+    drho = (rhomax-rhomin)/(nRho-1);
+    dU = (umax-umin)/(nU-1);
 
 	/*
 	 * Print P on a rho x u grid.
@@ -53,12 +61,12 @@ void main(int argc, char **argv) {
 	fprintf(stderr, "Printing grid using tillPressureSoundNP()...\n");
 
 	/* Print a rho x u grid. */
-	for (i=0; i<nRho; i+=1)
+	for (i=0; i<nU; i+=1)
 	{
-		rho = rhomin + i*drho;
-		for (j=0; j<nU; j+=1)
+		u = umin + i*dU;
+		for (j=0; j<nRho; j+=1)
 		{
-			u = umin + j*dU;
+		    rho = rhomin + j*drho;
 			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL));
 		}
 		fprintf(fp,"\n");
@@ -71,12 +79,14 @@ void main(int argc, char **argv) {
 	fprintf(stderr, "Printing grid using tillPressure()...\n");
 
 	/* Print a rho x u grid. */
-	for (i=0; i<nRho; i+=1)
+	for (i=0; i<nU; i+=1)
 	{
-		rho = rhomin + i*drho;
-		for (j=0; j<nU; j+=1)
+        u = umin + i*dU;
+
+		for (j=0; j<nRho; j+=1)
 		{
-			u = umin + j*dU;
+            rho = rhomin + j*drho;
+
 			fprintf(fp," %15.7E", tillPressure(tillmat, rho, u));
 		}
 		fprintf(fp,"\n");
@@ -87,13 +97,14 @@ void main(int argc, char **argv) {
 	assert(fp != NULL);
 
 	/* print a rho x u grid. */
-	for (i=0; i<nRho; i+=1)
+	for (i=0; i<nU; i+=1)
 	{
-		rho = rhomin + i*drho;
+        u = umin + i*dU;
 
-		for (j=0; j<nU; j+=1)
+		for (j=0; j<nRho; j+=1)
 		{
-			u = umin + j*dU;
+            rho = rhomin + j*drho;
+
 			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL)-
                     tillPressure(tillmat, rho, u));
 		}
@@ -106,19 +117,19 @@ void main(int argc, char **argv) {
 	assert(fp != NULL);
 
 	/* print a rho x u grid. */
-	for (i=0; i<nRho; i+=1)
+	for (i=0; i<nU; i+=1)
 	{
-		rho = rhomin + i*drho;
+        u = umin + i*dU;
 
-		for (j=0; j<nU; j+=1)
+		for (j=0; j<nRho; j+=1)
 		{
-			u = umin + j*dU;
-            
-            if (tillPressureSoundNP(tillmat, rho, u, NULL) < 0.0)
+            rho = rhomin + j*drho;
+//            if (tillPressureSoundNP(tillmat, rho, u, NULL) <= 0.0)
+            if (tillPressureSound(tillmat, rho, u, NULL) <= 0.0)
             {
-                fprintf(fp," %3i", -1);
+                fprintf(fp," %2i", 0);
             } else {
-                fprintf(fp," %3i", 0);
+                fprintf(fp," %2i", 1);
             }
 		}
 		fprintf(fp,"\n");

--- a/testtillpressure_np.c
+++ b/testtillpressure_np.c
@@ -20,12 +20,12 @@ void main(int argc, char **argv) {
 	double dMsolUnit = 4.80438e-08;
     // Define the size of the grid
     double rhomin = 1e-4;
-	double rhomax = 100.0;
+	double rhomax = 10.0;
     double vmax = 100.0;
-	double umax = 100.0;
+	double umax = 25.0;
 	double umin = 0.0;
-	int nRho = 1000;
-	int nU = 1000;
+	int nRho = 100;
+	int nU = 100;
     double drho, dU;
 
 	double rho;
@@ -84,24 +84,47 @@ void main(int argc, char **argv) {
 	fclose(fp);
 
 	fp = fopen("testtillpressure_np_diff.txt", "w");
-	assert(fp != NULL);
+	assert(fp != null);
 
-	fprintf(stderr, "Printing grid for the ideal gas EOS...\n");
+	fprintf(stderr, "printing grid for the ideal gas eos...\n");
 
-	/* Print a rho x u grid. */
-	for (i=0; i<nRho; i+=1)
+	/* print a rho x u grid. */
+	for (i=0; i<nrho; i+=1)
 	{
 		rho = rhomin + i*drho;
 
-		for (j=0; j<nU; j+=1)
+		for (j=0; j<nu; j+=1)
 		{
-			u = umin + j*dU;
-			fprintf(fp," %15.7E", tillPressureSoundNP(tillmat, rho, u, NULL)-
-                    tillPressure(tillmat, rho, u));
+			u = umin + j*du;
+			fprintf(fp," %15.7e", tillpressuresoundnp(tillmat, rho, u, null)-
+                    tillpressure(tillmat, rho, u));
 		}
 		fprintf(fp,"\n");
 	}
+	fclose(fp);
 
+    /* Plot where P is negative. */
+	fp = fopen("testtillpressure_np_region.txt", "w");
+	assert(fp != null);
+
+	/* print a rho x u grid. */
+	for (i=0; i<nrho; i+=1)
+	{
+		rho = rhomin + i*drho;
+
+		for (j=0; j<nu; j+=1)
+		{
+			u = umin + j*du;
+            
+            if (tillpressuresoundnp(tillmat, rho, u, null) < 0.0)
+            {
+                fprintf(fp," %3i", -1);
+            } else {
+                fprintf(fp," %3i", 0);
+            }
+		}
+		fprintf(fp,"\n");
+	}
 	fclose(fp);
 	tillFinalizeMaterial(tillmat);
 }

--- a/testtillpressure_np.py
+++ b/testtillpressure_np.py
@@ -174,6 +174,28 @@ colorbar()
 
 savefig('testtillpressure_np_region.png', dpi=300, bbox_inches='tight')
 
+fig.clear()
+
+"""
+Plot P(rho, T).
+"""
+data = loadtxt('testtillpressure_np_rhot.txt')
+
+rho = data[:,0]
+
+for i in range(1,size(data[1,:]),1):
+    plot(data[:,0],data[:,i],'-',color='red',markersize=1,label='T')
+
+rho_min = min(rho)
+rho_max = max(rho)
+
+xlim(rho_min, rho_max)
+#ylim(0, 4)
+
+xlabel("Density [code units]")
+ylabel("Pressure [code units]")
+
+savefig('testtillpressure_np_rhot.png', dpi=300, bbox_inches='tight')
 
 show()
 

--- a/testtillpressure_np.py
+++ b/testtillpressure_np.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python2
+"""
+This script compares pressure calculated in tillPressureSoundNP with the results from tillPressure.
+"""
+from matplotlib import *
+rcParams['font.family'] = 'serif'
+from numpy import *
+from matplotlib.pyplot import *
+
+"""
+Setup the plot.
+"""
+# Set a font
+rcParams['font.family'] = 'serif'
+rcParams['font.size'] = 10.0
+
+# Legend
+# mpl.rcParams['legend.handlelength']  = 2.9
+rcParams['legend.handlelength']  = 0.5
+rcParams['legend.frameon']       = False
+rcParams['legend.numpoints']     = 1
+rcParams['legend.scatterpoints'] = 1
+
+# Adjust axes line width
+rcParams['axes.linewidth']   = 0.5
+
+# Adjust ticks
+rcParams['xtick.major.size'] = 4
+rcParams['xtick.minor.size'] = 2
+rcParams['ytick.major.size'] = 4
+rcParams['ytick.minor.size'] = 2
+
+# Adjust Font Size
+rcParams['xtick.labelsize']  = 'x-small'
+rcParams['ytick.labelsize']  = 'x-small'
+rcParams['axes.labelsize']   = 'small'
+
+# Set Up Figure, Single Column MNRAS
+fig = gcf()
+ax = gca()
+fig, ax = subplots(1,1)
+fig.set_size_inches(8.27*0.39,8.27*(6./8.)*0.39)
+
+"""
+data1 = loadtxt('out.old.dat',skiprows=3)
+data2 = loadtxt('out.dat',skiprows=3)
+"""
+
+# Tillotson material
+data1 = loadtxt('testtillpressure_np.txt')
+data2 = loadtxt('testtillpressure.txt')
+data3 = loadtxt('testtillpressure_np_diff.txt')
+
+print where(fabs(data1-data2) > 1e-30)
+print
+print where(fabs(data3) > 1e-30);
+
+figure(1)
+imshow(data1-data2)
+
+figure(2)
+imshow(data1)
+
+figure(3)
+imshow(data2)
+
+figure(4)
+imshow(data3)
+
+show()
+

--- a/testtillpressure_np.py
+++ b/testtillpressure_np.py
@@ -111,12 +111,36 @@ rho0 = 2.7
 us   = 3.5e10
 us2  = 1.8e11
 
-# Plot the difference between tillPressureSoundNP and tillPressure
+rho_min = 1e-4
+rho_max = 10.0
+u_min   = 0.0
+u_max   = 25.0
+
+rho_min = 1e-4
+rho_max = 8.0602
+u_min   = 0.0
+u_max   = 19.8035
+
+# Convert to cgs
+rho_min *= dGmPerCcUnit
+rho_max *= dGmPerCcUnit
+
+u_min   *= dErgPerGmUnit
+u_max   *= dErgPerGmUnit
+
+print dGmPerCcUnit
+print dErgPerGmUnit
+
+print "rho_min=", rho_min, "rho_max=", rho_max
+print "u_min  =", u_min, "u_max  =", u_max
+
+"""
+Plot the difference between tillPressureSoundNP and tillPressure.
+"""
 data = loadtxt('testtillpressure_np_diff.txt')
 
 print where(fabs(data) < 1e-10)
 
-#figure(1)
 imshow(data, origin='lower', extent=(rho_min, rho_max, u_min, u_max), aspect='auto')
 
 plot([rho0, rho0], [u_min, u_max], '--', color='red')
@@ -128,8 +152,27 @@ ylabel("Int. energy [code units]")
 
 colorbar()
 
-savefig('testtillpressure_np.png', dpi=300, bbox_inches='tight')
+savefig('testtillpressure_np_diff.png', dpi=300, bbox_inches='tight')
 
+fig.clear()
+
+"""
+Plot where the pressure is negative.
+"""
+data = loadtxt('testtillpressure_np_region.txt')
+
+imshow(data, origin='lower', extent=(rho_min, rho_max, u_min, u_max), aspect='auto')
+
+plot([rho0, rho0], [u_min, u_max], '--', color='red')
+plot([rho_min, rho_max], [us, us], '--', color='red')
+plot([rho_min, rho_max], [us2, us2], '--', color='red')
+
+xlabel("Density [code units]")
+ylabel("Int. energy [code units]")
+
+colorbar()
+
+savefig('testtillpressure_np_region.png', dpi=300, bbox_inches='tight')
 
 
 show()

--- a/tillotson.c
+++ b/tillotson.c
@@ -1247,10 +1247,6 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
 
     gsl_root_fsolver_set(Solver, &F, rho_min, rho_max);
 
-#if TILL_VERBOSE
-//      fprintf(stderr, "tillRhoPTemp: Using solver %s.\n", gsl_root_fsolver_name(Solver));
-#endif
-
 #if 0
     // Make sure that Pb > P. If nescessary the lookup table has to be expanded.
     while (Pmax < P)

--- a/tillotson.c
+++ b/tillotson.c
@@ -1285,6 +1285,27 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
     assert (Pa < P && P < Pb);	
 #endif
 
+    /*
+     * Check if P_min < P < P_max so the root finder does not crash.
+     *
+     * Note: In the future we might want to expand the lookup table if P>=P_max.
+     */
+    if (P <= eosPressureRhoT(material, rho_min, T)) {       
+#ifdef TILL_VERBOSE
+        fprintf(stderr, "tillRhoPTemp: P <= P(rho_min, T) (P= %g, rho_min= %g, P_min= %g T=%g).\n",
+                P, rho_min, eosPressure(material, rho_min, T), T);
+#endif
+        return -1.0;
+    }
+    
+    if (P >= eosPressureRhoT(material, rho_max, T)) {       
+#ifdef TILL_VERBOSE
+        fprintf(stderr, "tillRhoPTemp: P >= P(rho_max, T) (P= %g, rho_max= %g, P_max= %g T=%g).\n",
+                P, rho_max, eosPressure(material, rho_max, T), T);
+#endif
+        return -1.0;
+    }
+    
     for (i=0; i<max_iter; i++)
     {
         // Do one iteration of the root solver

--- a/tillotson.c
+++ b/tillotson.c
@@ -776,6 +776,19 @@ double tillPressureSoundNP(TILLMATERIAL *material, double rho, double u, double 
         Gammae = material->a + material->b/w0*exp(-material->beta*z*z);
         Pe = Gammae*u*rho + material->A*mu*exp(-(material->alpha*z+material->beta*z*z));
 
+        /*
+         * Set Pc to zero if it is negative so it does not contribute to the pressure in the
+         * expanded, intermediate states.
+         */
+#ifdef TILL_PRESS_MELOSH
+        if (eta < 0.8)
+        {
+            Pc = 0.0;
+        }
+#endif
+#ifdef TILL_PRESS_NP
+        if (Pc < 0.0) Pc = 0.0;
+#endif
         if (pcSound != NULL)
         {
             /* calculate the sound speed */

--- a/tillotson.c
+++ b/tillotson.c
@@ -1240,6 +1240,27 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
     }
 #endif
 
+    /*
+     * Check if P_min < P < P_max so the root finder does not crash.
+     *
+     * Note: In the future we might want to expand the lookup table if P>=P_max.
+     */
+    if (P <= eosPressureRhoT(material, rho_min, T)) {       
+#ifdef TILL_VERBOSE
+        fprintf(stderr, "tillRhoPTemp: P <= P(rho_min, T) (P= %g, rho_min= %g, P_min= %g T=%g).\n",
+                P, rho_min, eosPressureRhoT(material, rho_min, T), T);
+#endif
+        return -1.0;
+    }
+    
+    if (P >= eosPressureRhoT(material, rho_max, T)) {       
+#ifdef TILL_VERBOSE
+        fprintf(stderr, "tillRhoPTemp: P >= P(rho_max, T) (P= %g, rho_max= %g, P_max= %g T=%g).\n",
+                P, rho_max, eosPressureRhoT(material, rho_max, T), T);
+#endif
+        return -1.0;
+    }
+
     // Initialize the root finder
     SolverType = gsl_root_fsolver_brent;
     Solver = gsl_root_fsolver_alloc(SolverType);
@@ -1284,27 +1305,6 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
 
     assert (Pa < P && P < Pb);	
 #endif
-
-    /*
-     * Check if P_min < P < P_max so the root finder does not crash.
-     *
-     * Note: In the future we might want to expand the lookup table if P>=P_max.
-     */
-    if (P <= eosPressureRhoT(material, rho_min, T)) {       
-#ifdef TILL_VERBOSE
-        fprintf(stderr, "tillRhoPTemp: P <= P(rho_min, T) (P= %g, rho_min= %g, P_min= %g T=%g).\n",
-                P, rho_min, eosPressure(material, rho_min, T), T);
-#endif
-        return -1.0;
-    }
-    
-    if (P >= eosPressureRhoT(material, rho_max, T)) {       
-#ifdef TILL_VERBOSE
-        fprintf(stderr, "tillRhoPTemp: P >= P(rho_max, T) (P= %g, rho_max= %g, P_max= %g T=%g).\n",
-                P, rho_max, eosPressure(material, rho_max, T), T);
-#endif
-        return -1.0;
-    }
     
     for (i=0; i<max_iter; i++)
     {

--- a/tillotson.c
+++ b/tillotson.c
@@ -1229,22 +1229,6 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
     rho_min = 1e-10;
     rho_max = 0.999*material->rhomax;
 
-    // Check if the root can be bracketed
-    double u;
-    double P_min, P_max;
-
-    fprintf(stderr, "P= %g T= %g rho_min= %g rho_max= %g\n", P, T, rho_min, rho_max);
-
-    u = eosURhoTemp(material, rho_min, T);
-    P_min = tillPressureSoundNP(material, rho_min, u, NULL);
-    fprintf(stderr, "u_min= %g P_min= %g dP_min= %g\n", u, P_min, P_min-P);
-
-    u = eosURhoTemp(material, rho_max, T);
-    P_max = tillPressureSoundNP(material, rho_max, u, NULL);
-
-    fprintf(stderr, "u_max= %g P_max= %g dP_max= %g\n", u, P_max, P_max-P);
-
-    assert (P_min < P && P < P_max);	
 #if 0
     // Check if P(rho_min, T) < P otherwise the root can not be bracketed.
     if (eosPressureRhoT(material, rho_min, T) > P) {
@@ -1261,10 +1245,6 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
     Solver = gsl_root_fsolver_alloc(SolverType);
     assert(Solver != NULL);
 
-    /// CR: Some debug code
-//    fprintf(stderr, "rho_min= %g P_min= %g rho_max= %g P_max= %g\n", rho_min, eosPressureRhoT(material, rho_min, T),
-//            rho_max, eosPressureRhoT(material, rho_max, T));
-    fprintf(stderr, "Setting root finder...\n");
     gsl_root_fsolver_set(Solver, &F, rho_min, rho_max);
 
 #if TILL_VERBOSE
@@ -1308,17 +1288,6 @@ double tillRhoPTemp(TILLMATERIAL *material, double P, double T)
 
     assert (Pa < P && P < Pb);	
 #endif
-
-    // CR: More debug
-
-    fprintf(stderr, "PressureRhoT_GSL: P_min= %g ", PressureRhoT_GSL(rho_min, (void *) &Params));
-    fprintf(stderr, "P_max= %g\n", PressureRhoT_GSL(rho_max, (void *) &Params));
-    fprintf(stderr, "PressureRhoT_GSL: dP_min= %g ", PressureRhoT_GSL(rho_min, (void *) &Params)-P);
-    fprintf(stderr, "dP_max= %g\n", PressureRhoT_GSL(rho_max, (void *) &Params)-P);
-
-    fprintf(stderr, "GSL_FN_EVAL: P_min= %g ", GSL_FN_EVAL(&F, rho_min));
-    fprintf(stderr, "P_max= %g\n", GSL_FN_EVAL(&F, rho_max));
-    fprintf(stderr, "\n");
 
     for (i=0; i<max_iter; i++)
     {

--- a/tillotson.c
+++ b/tillotson.c
@@ -1159,6 +1159,7 @@ double PressureRhoT_GSL(double rho, void *params)
     TILLMATERIAL *material;
     double P;
     double T;
+    double u;
 
     struct PressureRhoT_GSL_Params *p;
 

--- a/tillotson.h
+++ b/tillotson.h
@@ -174,6 +174,7 @@ double eosPhi(TILLMATERIAL *material, double rho, double u);
 double eosGamma(TILLMATERIAL *material, double rho, double u);
 
 double tilldPdrho(TILLMATERIAL *material, double rho, double u);
+double tillPressureSoundNP(TILLMATERIAL *material, double rho, double u, double *pcSound);
 double tillPressureSound(TILLMATERIAL *material, double rho, double u, double *pcSound);
 double tillPressure(TILLMATERIAL *material, double rho, double u);
 double tillPressureNP(TILLMATERIAL *material, double rho, double u);


### PR DESCRIPTION
I improved the root finding in tillRhoPTemp by allowing the pressure in the expanded, cold states to be negative (only for root finding) so P(rho) is always strictly monotonic. Now densities around 1e-10 and temperatures close to zero can be reliably calculated.