### PR TITLE
Remove output when the library is initialized

### DIFF
--- a/tillinitlookup.c
+++ b/tillinitlookup.c
@@ -109,8 +109,6 @@ void tillInitLookup(TILLMATERIAL *material, int nTableRho, int nTableV, double r
 
 	v = 0.0;
 	dv = material->dv;
-
-	fprintf(stderr,"tillInitLookup: Solving ODEs.\n");
     
 	/*
      * Integrate the isentropes for different v.

--- a/tillinitlookup.c
+++ b/tillinitlookup.c
@@ -103,11 +103,6 @@ void tillInitLookup(TILLMATERIAL *material, int nTableRho, int nTableV, double r
     /* This is the same for all materials. */
     material->dv = material->vmax/(material->nTableV-1);
 
-#ifdef TILL_VERBOSE
-    fprintf(stderr, "tillInitLookup: iMat= %i n= %i dlogrho= %g dv= %g.\n", material->iMaterial, material->n, material->dlogrho, material->dv);
-    fprintf(stderr, "tillInitLookup: nTableRho= %i nTableV= %i.\n", material->nTableRho, material->nTableV);
-#endif
-
 	/* We arrange the look up table as a 1D array with Lookup[i][j] = Lookup[i*Ntable+j] */
     material->Lookup = calloc(material->nTableRho*material->nTableV, sizeof(TILL_LOOKUP_ENTRY));
     assert(material->Lookup != NULL);
@@ -136,9 +131,7 @@ void tillInitLookup(TILLMATERIAL *material, int nTableRho, int nTableV, double r
 	}
 
     /* Solve splines for both u and u1 in v storing the 2nd derivatives wrt v */
-	fprintf(stderr,"tillInitLookup: Init splines.\n");
 	tillInitSplines(material);
-	fprintf(stderr,"tillInitLookup: Splines initialised.\n");	
 }
 
 TILL_LOOKUP_ENTRY *tillSolveIsentrope(TILLMATERIAL *material, double v)

--- a/tillotson.c
+++ b/tillotson.c
@@ -134,10 +134,6 @@ TILLMATERIAL *tillInitMaterial(int iMaterial, double dKpcUnit, double dMsolUnit)
             material->b = 26.6/(material->dMeanMolMass*MHYDR*NA);
             material->b = 0.0; 
             material->a = 0.0;
-#ifdef TILL_VERBOSE
-            fprintf(stderr, "tillInitMaterial: Modified ideal gas: b=  %g [cm^3/g]\n", material->b);
-            fprintf(stderr, "tillInitMaterial: Modified ideal gas: mu= %g [1/m_H]\n", material->dMeanMolMass);
-#endif
 			break;
 		case GRANITE:
 			/*

--- a/tillotson.c
+++ b/tillotson.c
@@ -107,12 +107,7 @@ TILLMATERIAL *tillInitMaterial(int iMaterial, double dKpcUnit, double dMsolUnit)
 //          material->dMeanMolMass = 11.5;  // 5x solar value (mu=2.3)
 //          material->dMeanMolMass = 17.25; // 7.5x solar value (mu=2.3)
 //          material->dMeanMolMass = 2.3;   // solar value (mu=2.3)
-#if 0
-            /*
-             * This doesnt work as cv is converted to code units below.
-             */
-            material->cv = material->dGasConst/((material->dConstGamma-1.0)*material->dMeanMolMass);
-#endif
+
             // cv = kb/mp
             material->cv = KBOLTZ/((material->dConstGamma-1.0)*MHYDR*material->dMeanMolMass);
             material->rho0 = 0.001;

--- a/tillotson.c
+++ b/tillotson.c
@@ -260,15 +260,7 @@ TILLMATERIAL *tillInitMaterial(int iMaterial, double dKpcUnit, double dMsolUnit)
     if (iMaterial == IDEALGAS)
     {
         material->b *=material->dGmPerCcUnit;
-//        fprintf(stderr, "b= %g [RE^3/Munit]\n", material->b);
     }
-
-#if 0
-    if (material->iMaterial == IDEALGAS)
-    {
-        fprintf(stderr, "Ideal gas: cv= %g\n in code units.\n", material->cv);
-    }
-#endif
 
     return material;
 }

--- a/tillotson.h
+++ b/tillotson.h
@@ -9,10 +9,10 @@
 /*
  * Version.
  */
-#define TILL_VERSION_TEXT    "3.3.0"
+#define TILL_VERSION_TEXT    "3.3.1"
 #define TILL_VERSION_MAJOR   3
 #define TILL_VERSION_MINOR   3
-#define TILL_VERSION_PATCH   0
+#define TILL_VERSION_PATCH   1
 
 /*
  * Error codes.


### PR DESCRIPTION
There was too much output, which was especially bothering when Gasoline called the library for each thread.